### PR TITLE
Fix early stopping

### DIFF
--- a/tasks/classification_manager.py
+++ b/tasks/classification_manager.py
@@ -23,7 +23,7 @@ class Classification_Manager(SimpleTrainer):
                             100 * self.model.best_stats.val.recall, 100 * self.model.best_stats.val.f1score,
                             self.model.best_stats.val.loss)
 
-        def validate_epoch(self, valid_set, valid_loader, early_Stopping, epoch, global_bar):
+        def validate_epoch(self, valid_set, valid_loader, early_stopping, epoch, global_bar):
             if valid_set is not None and valid_loader is not None:
                 # Set model in validation mode
                 self.model.net.eval()
@@ -32,9 +32,8 @@ class Classification_Manager(SimpleTrainer):
 
                 # Early stopping checking
                 if self.cf.early_stopping:
-                    early_Stopping.check(self.stats.train.loss, self.stats.val.loss, self.stats.val.mIoU,
-                                         self.stats.val.acc)
-                    if early_Stopping.stop == True:
+                    if early_stopping.check(self.stats.train.loss, self.stats.val.loss, self.stats.val.mIoU,
+                                            self.stats.val.acc, self.stats.val.f1score):
                         self.stop = True
 
                 # Set model in training mode

--- a/tasks/simple_trainer_manager.py
+++ b/tasks/simple_trainer_manager.py
@@ -8,7 +8,7 @@ import os
 from torch.autograd import Variable
 
 sys.path.append('../')
-from utils.tools import AverageMeter, Early_Stopping
+from utils.tools import AverageMeter, EarlyStopping
 from utils.ProgressBar import ProgressBar
 from utils.logger import Logger
 from utils.statistics import Statistics
@@ -52,9 +52,9 @@ class SimpleTrainer(object):
                                                                     float(self.cf.valid_batch_size))
             # Define early stopping control
             if self.cf.early_stopping:
-                early_Stopping = Early_Stopping(self.cf)
+                early_stopping = EarlyStopping(self.cf)
             else:
-                early_Stopping = None
+                early_stopping = None
 
             prev_msg = '\nTotal estimated training time...\n'
             self.global_bar = ProgressBar((self.cf.epochs+1-self.curr_epoch)*(self.train_num_batches+self.val_num_batches), lenBar=20)
@@ -92,7 +92,7 @@ class SimpleTrainer(object):
                                                                                 'train_epoch_' + str(epoch) + '.json'))
 
                 # Validate epoch
-                self.validate_epoch(valid_set, valid_loader, early_Stopping, epoch, self.global_bar)
+                self.validate_epoch(valid_set, valid_loader, early_stopping, epoch, self.global_bar)
 
                 # Update scheduler
                 if self.model.scheduler is not None:
@@ -173,7 +173,7 @@ class SimpleTrainer(object):
             self.stats.train.acc = np.nanmean(mean_accuracy)
             self.stats.train.loss = float(train_loss.avg.cpu().data)
 
-        def validate_epoch(self,valid_set, valid_loader, early_Stopping, epoch, global_bar):
+        def validate_epoch(self, valid_set, valid_loader, early_stopping, epoch, global_bar):
 
             if valid_set is not None and valid_loader is not None:
                 # Set model in validation mode
@@ -183,10 +183,10 @@ class SimpleTrainer(object):
 
                 # Early stopping checking
                 if self.cf.early_stopping:
-                    early_Stopping.check(self.stats.train.loss, self.stats.val.loss, self.stats.val.mIoU,
-                                         self.stats.val.acc)
-                    if early_Stopping.stop == True:
-                        self.stop=True
+                    if early_stopping.check(self.stats.train.loss, self.stats.val.loss, self.stats.val.mIoU,
+                                            self.stats.val.acc, self.stats.val.f1score):
+                        self.stop = True
+
                 # Set model in training mode
                 self.model.net.train()
 

--- a/utils/tools.py
+++ b/utils/tools.py
@@ -60,46 +60,53 @@ def save_prediction(output_path, predictions, names):
         output_file = output_path + names[img]
         cv.imwrite(output_file, np.squeeze(predictions[img], axis=2))
 
-class Early_Stopping():
+
+class EarlyStopping:
     def __init__(self, cf):
         self.cf = cf
         self.best_loss_metric = float('inf')
         self.best_metric = 0
         self.counter = 0
         self.patience = self.cf.patience
-        self.stop = False
 
-    def check(self, save_condition, train_mLoss, valid_mLoss=None, 
-                mIoU_valid=None, mAcc_valid=None):
+    def check(self, train_loss, val_loss=None, val_mIoU=None, val_acc=None, val_f1score=None):
         if self.cf.stop_condition == 'train_loss':
-            if train_mLoss < self.best_loss_metric:
-                self.best_loss_metric = train_mLoss
+            if train_loss < self.best_loss_metric:
+                self.best_loss_metric = train_loss
                 self.counter = 0
             else:
                 self.counter += 1
         elif self.cf.stop_condition == 'valid_loss':
-            if valid_mLoss < self.best_loss_metric:
-                self.best_loss_metric = valid_mLoss
+            if val_loss < self.best_loss_metric:
+                self.best_loss_metric = val_loss
                 self.counter = 0
             else:
                 self.counter += 1
         elif self.cf.stop_condition == 'valid_mIoU':
-            if mIoU_valid > self.best_metric:
-                self.best_metric = mIoU_valid
+            if val_mIoU > self.best_metric:
+                self.best_metric = val_mIoU
                 self.counter = 0
             else:
                 self.counter += 1
         elif self.cf.stop_condition == 'valid_mAcc':
-            if mAcc_valid > self.best_metric:
-                self.best_metric = mAcc_valid
+            if val_acc > self.best_metric:
+                self.best_metric = val_acc
                 self.counter = 0
             else:
                 self.counter += 1
+        elif self.cf.stop_condition == 'f1_score':
+            if val_f1score > self.best_metric:
+                self.best_metric = val_f1score
+                self.counter = 0
+            else:
+                self.counter += 1
+
         if self.counter == self.patience:
             print(' Early Stopping Interruption\n')
             return True
         else:
             return False
+
 
 class AverageMeter(object):
     def __init__(self):


### PR DESCRIPTION
The boolean variable `EarlyStopping.stop` is being checked in order to stop the training, but the `EarlyStopping` class never sets that variable. Instead, the method `EarlyStopping.check()` returns a boolean, which is ignored. I changed the code to stop using the `EarlyStopping.stop` variable and use the return value of the `EarlyStopping.check()` function.

Also, I added the `f1_score` stop condition, which is used in the default classification configuration.