### PR TITLE
Fix early stopping

### DIFF
--- a/tasks/semanticSegmentator_manager.py
+++ b/tasks/semanticSegmentator_manager.py
@@ -33,9 +33,8 @@ class SemanticSegmentation_Manager(SimpleTrainer):
 
                 # Early stopping checking
                 if self.cf.early_stopping:
-                    early_Stopping.check(self.stats.train.loss, self.stats.val.loss, self.stats.val.mIoU,
-                                         self.stats.val.acc)
-                    if early_Stopping.stop == True:
+                    if early_Stopping.check(self.stats.train.loss, self.stats.val.loss, self.stats.val.mIoU,
+                                         self.stats.val.acc):
                         self.stop = True
 
                 # Set model in training mode


### PR DESCRIPTION
`'EarlyStopping' object has no attribute 'stop'`, so we have to check the output of the function `check`